### PR TITLE
Implement AWS OpenSearch Service Sign request

### DIFF
--- a/fluent-plugin-opensearch.gemspec
+++ b/fluent-plugin-opensearch.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', '>= 0.14.22'
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'opensearch-ruby'
+  s.add_runtime_dependency "aws-sdk-core", "~> 3"
+  s.add_runtime_dependency "faraday_middleware-aws-sigv4"
 
 
   s.add_development_dependency 'rake', '>= 0'

--- a/test/plugin/test_out_opensearch.rb
+++ b/test/plugin/test_out_opensearch.rb
@@ -286,6 +286,35 @@ class OpenSearchOutputTest < Test::Unit::TestCase
     assert_false instance.compression
     assert_equal :no_compression, instance.compression_level
     assert_true instance.http_backend_excon_nonblock
+
+    assert_nil instance.endpoint
+  end
+
+  test 'configure endpoint section' do
+    config = Fluent::Config::Element.new(
+      'ROOT', '', {
+        '@type' => 'opensearch',
+      }, [
+        Fluent::Config::Element.new('endpoint', '', {
+                                      'url' => "https://search-opensearch.aws.example.com/",
+                                      'region' => "local",
+                                      'access_key_id' => 'YOUR_AWESOME_KEY',
+                                      'secret_access_key' => 'YOUR_AWESOME_SECRET',
+                                    }, []),
+        Fluent::Config::Element.new('buffer', 'tag', {}, [])
+
+      ])
+    instance = driver(config).instance
+
+    assert_equal "https://search-opensearch.aws.example.com", instance.endpoint.url
+    assert_equal "local", instance.endpoint.region
+    assert_equal "YOUR_AWESOME_KEY", instance.endpoint.access_key_id
+    assert_equal "YOUR_AWESOME_SECRET", instance.endpoint.secret_access_key
+    assert_nil instance.endpoint.assume_role_arn
+    assert_nil instance.endpoint.ecs_container_credentials_relative_uri
+    assert_equal "fluentd", instance.endpoint.assume_role_session_name
+    assert_nil instance.endpoint.assume_role_web_identity_token_file
+    assert_nil instance.endpoint.sts_credentials_region
   end
 
   test 'configure compression' do


### PR DESCRIPTION
Closes https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/pull/77

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

It is reasonable to handle events ingestions of AWS OpenSearch service on fluent-plugin-opensearch it self.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
