### PR TITLE
Retry creating data stream/template when OpenSearch is unreachable

### DIFF
--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -31,16 +31,16 @@ module Fluent::Plugin
 
       @client = client
       unless @use_placeholder
-        delay = 1
         begin
           @data_stream_names = [@data_stream_name]
-          create_index_template(@data_stream_name, @data_stream_template_name, @host)
-          create_data_stream(@data_stream_name)
+          retry_operate(@max_retry_putting_template,
+                        @fail_on_putting_template_retry_exceed,
+                        @catch_transport_exception_on_retry) do
+            create_index_template(@data_stream_name, @data_stream_template_name, @host)
+            create_data_stream(@data_stream_name)
+          end
         rescue => e
-          log.info "Failed to create data stream, will retry in #{delay} second(s): <#{@data_stream_name}> #{e.message}"
-          sleep(delay)
-          delay *= 2
-          retry
+          raise Fluent::ConfigError, "Failed to create data stream: <#{@data_stream_name}> #{e.message}"
         end
       end
     end

--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -31,12 +31,16 @@ module Fluent::Plugin
 
       @client = client
       unless @use_placeholder
+        delay = 1
         begin
           @data_stream_names = [@data_stream_name]
           create_index_template(@data_stream_name, @data_stream_template_name, @host)
           create_data_stream(@data_stream_name)
         rescue => e
-          raise Fluent::ConfigError, "Failed to create data stream: <#{@data_stream_name}> #{e.message}"
+          log.info "Failed to create data stream, will retry in #{delay} second(s): <#{@data_stream_name}> #{e.message}"
+          sleep(delay)
+          delay *= 2
+          retry
         end
       end
     end

--- a/test/plugin/test_out_opensearch_data_stream.rb
+++ b/test/plugin/test_out_opensearch_data_stream.rb
@@ -58,7 +58,6 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
   end
 
   RESPONSE_ACKNOWLEDGED = {"acknowledged": true}
-  UNAUTHORIZED_DATA_STREAM_EXCEPTION = {"error": {}, "status": 401}
   DUPLICATED_DATA_STREAM_EXCEPTION = {"error": {}, "status": 400}
   NONEXISTENT_DATA_STREAM_EXCEPTION = {"error": {}, "status": 404}
 


### PR DESCRIPTION
If the OpenSearch backend is unreachable when the plugin starts its initial configuration, it will crash the Fluentd container (see #7). 
This PR fixes this by adding a retry mechanism to the configuration step, relying on eventual consistency. I did not add a limit to the retry, as the connection should either eventually work, or there is something wrong in the environment that requires manual intervention. 