### PR TITLE
Use template_file for Data Streams

### DIFF
--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -46,7 +46,7 @@ module Fluent::Plugin
 
     def validate_data_stream_parameters
       {"data_stream_name" => @data_stream_name,
-       "data_stream_template_name"=> @data_stream_template_name}.each do |parameter, value|
+       "data_stream_template_name" => @data_stream_template_name}.each do |parameter, value|
         unless valid_data_stream_parameters?(value)
           unless start_with_valid_characters?(value)
             if not_dots?(value)
@@ -69,19 +69,25 @@ module Fluent::Plugin
     end
 
     def create_index_template(datastream_name, template_name, host = nil)
-      return if data_stream_exist?(datastream_name, host) or template_exists?(template_name, host)
-      body = {
-        "index_patterns" => ["#{datastream_name}*"],
-        "data_stream" => {},
-      }
-      params = {
-        name: template_name,
-        body: body
-      }
-      retry_operate(@max_retry_putting_template,
-                    @fail_on_putting_template_retry_exceed,
-                    @catch_transport_exception_on_retry) do
-        client(host).indices.put_index_template(params)
+      # Create index template from file
+      if @template_file
+        template_installation_actual(template_name, @customize_template, @application_name, datastream_name, host)
+      else # Create default index template
+        return if data_stream_exist?(datastream_name, host) or template_exists?(template_name, host)
+        body = {
+          "index_patterns" => ["#{datastream_name}*"],
+          "data_stream" => {},
+        }
+
+        params = {
+          name: template_name,
+          body: body
+        }
+        retry_operate(@max_retry_putting_template,
+                      @fail_on_putting_template_retry_exceed,
+                      @catch_transport_exception_on_retry) do
+          client(host).indices.put_index_template(params)
+        end
       end
     end
 

--- a/test/plugin/datastream_template.json
+++ b/test/plugin/datastream_template.json
@@ -1,0 +1,4 @@
+{
+  "index_patterns": ["foo*"],
+  "data_stream": {}
+}

--- a/test/plugin/test_out_opensearch_data_stream.rb
+++ b/test/plugin/test_out_opensearch_data_stream.rb
@@ -367,6 +367,19 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     assert_equal "foo", driver(conf).instance.data_stream_name
   end
 
+  def test_template_file
+    stub_default
+    cwd = File.dirname(__FILE__)
+    conf = config_element(
+      'ROOT', '', {
+      '@type' => OPENSEARCH_DATA_STREAM_TYPE,
+      'data_stream_name' => 'foo',
+      'data_stream_template_name' => "foo_tpl",
+      'template_file' => File.join(cwd, 'datastream_template.json')
+    })
+    assert_equal "foo", driver(conf).instance.data_stream_name
+  end
+
   def test_existent_data_stream
     stub_index_template
     stub_existent_data_stream?


### PR DESCRIPTION
Signed-off-by: Anders Swanson <anders.swanson@oracle.com>

Currently template_file parameter is not supported by datastream output. This would add creation of index template, it was not working before.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
