### PR TITLE
opensearch_data_stream: Align lowercases for data_stream and its template names

### DIFF
--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -157,8 +157,8 @@ module Fluent::Plugin
                else
                  extract_placeholders(@host, chunk)
                end
-        data_stream_name = extract_placeholders(@data_stream_name, chunk)
-        data_stream_template_name = extract_placeholders(@data_stream_template_name, chunk)
+        data_stream_name = extract_placeholders(@data_stream_name, chunk).downcase
+        data_stream_template_name = extract_placeholders(@data_stream_template_name, chunk).downcase
         unless @data_stream_names.include?(data_stream_name)
           begin
             create_index_template(data_stream_name, data_stream_template_name, host)

--- a/test/plugin/test_out_opensearch_data_stream.rb
+++ b/test/plugin/test_out_opensearch_data_stream.rb
@@ -439,6 +439,23 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     assert_equal 1, @bulk_records
   end
 
+  def test_placeholder_with_capital_letters
+    dsname = "foo_test.capital_letters"
+    tplname = "foo_tpl_test.capital_letters"
+    stub_default(dsname, tplname)
+    stub_bulk_feed(dsname, tplname)
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => OPENSEARCH_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo_${tag}',
+        'data_stream_template_name' => "foo_tpl_${tag}"
+      })
+    driver(conf).run(default_tag: 'TEST.CAPITAL_LETTERS') do
+      driver.feed(sample_record)
+    end
+    assert_equal 1, @bulk_records
+  end
+
   def test_placeholder_params_unset
     dsname = "foo_test"
     tplname = "foo_test_template"


### PR DESCRIPTION
Closes https://github.com/fluent/fluent-plugin-opensearch/issues/48

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
