### PR TITLE
Expire AWS credentials with a certain interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1564,6 +1564,19 @@ In this case, the endpoint configuration looks like:
 </endpoint>
 ```
 
+### Expiring AWS credentials
+
+If you want to expire AWS credentials in certain interval, you should specify `refresh_credentials_interval` parameter under `endpoint` section:
+
+```aconf
+<endpoint>
+  url https://CLUSTER_ENDPOINT_URL
+  region eu-west-1
+  # ...
+  refresh_credentials_interval 3h # default is 5h (five hours).
+</endpoint>
+```
+
 ## Troubleshooting
 
 See [Troubleshooting document](README.Troubleshooting.md)

--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -597,6 +597,11 @@ module Fluent::Plugin
 
       @_os = nil unless is_existing_connection(connection_options[:hosts])
       @_os = nil unless @compressable_connection == compress_connection
+      # If AWS credentials is set, consider to create #client information on every requests.
+      if @endpoint
+        @_os = nil
+        @_aws_credentials = aws_credentials(@endpoint)
+      end
 
       @_os ||= begin
         @compressable_connection = compress_connection
@@ -607,7 +612,7 @@ module Fluent::Plugin
                              :aws_sigv4,
                              service: 'es',
                              region: @endpoint.region,
-                             credentials: aws_credentials(@endpoint),
+                             credentials: @_aws_credentials,
                            )
 
                            f.adapter @http_backend, @backend_options

--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -194,6 +194,7 @@ module Fluent::Plugin
       config_param :assume_role_session_name, :string, :default => "fluentd"
       config_param :assume_role_web_identity_token_file, :string, :default => nil
       config_param :sts_credentials_region, :string, :default => nil
+      config_param :refresh_credentials_interval, :time, :default => "5h"
     end
 
     config_section :buffer do
@@ -334,6 +335,22 @@ module Fluent::Plugin
           @truncate_mutex.synchronize {
             @template_names.clear
           }
+        end
+      end
+      # If AWS credentials is set, consider to expire credentials information forcibly before expired.
+      @credential_mutex = Mutex.new
+      if @endpoint
+        @_aws_credentials = aws_credentials(@endpoint)
+
+        if @endpoint.refresh_credentials_interval
+          timer_execute(:out_opensearch_expire_credentials, @endpoint.refresh_credentials_interval) do
+            log.debug('Recreate the AWS credentials')
+
+            @credential_mutex.synchronize do
+              @_os = nil
+              @_aws_credentials = aws_credentials(@endpoint)
+            end
+          end
         end
       end
 
@@ -597,11 +614,6 @@ module Fluent::Plugin
 
       @_os = nil unless is_existing_connection(connection_options[:hosts])
       @_os = nil unless @compressable_connection == compress_connection
-      # If AWS credentials is set, consider to create #client information on every requests.
-      if @endpoint
-        @_os = nil
-        @_aws_credentials = aws_credentials(@endpoint)
-      end
 
       @_os ||= begin
         @compressable_connection = compress_connection


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

Closes https://github.com/fluent/fluent-plugin-opensearch/issues/24
Closes #46 

For stable retrieving AWS credentials, we should obtain AWS credentials on every requests.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
