### PR TITLE
out_opensearch: Handle suppress_type_name operation correctly

### DIFF
--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -989,7 +989,7 @@ module Fluent::Plugin
         end
       end
 
-      if @suppress_type_name
+      if @suppress_type_name || @last_seen_major_version >= 2
         target_type = nil
       else
         # OpenSearch only supports "_doc".
@@ -998,7 +998,7 @@ module Fluent::Plugin
 
       meta.clear
       meta["_index".freeze] = target_index
-      meta["_type".freeze] = target_type
+      meta["_type".freeze] = target_type unless target_type.nil?
       meta["_alias".freeze] = target_index_alias
 
       if @pipeline

--- a/test/plugin/test_out_opensearch.rb
+++ b/test/plugin/test_out_opensearch.rb
@@ -2320,8 +2320,9 @@ class OpenSearchOutputTest < Test::Unit::TestCase
   end
 
   data(
-    "OpenSearch default"=> {"os_version" => 1, "_type" => "_doc", "suppress_type" => false},
-    "Suppressed type" => {"os_version" => 1, "_type" => nil, "suppress_type" => true},
+    "OpenSearch default" => {"os_version" => 1, "_type" => "_doc", "suppress_type" => false},
+    "Suppressed type"    => {"os_version" => 1, "_type" => nil,    "suppress_type" => true},
+    "OpenSearch 2"       => {"os_version" => 2, "_type" => nil,    "suppress_type" => true},
   )
   def test_writes_to_speficied_type(data)
     driver('', data["os_version"]).configure("suppress_type_name #{data['suppress_type']}")
@@ -2330,7 +2331,12 @@ class OpenSearchOutputTest < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal(data['_type'], index_cmds.first['index']['_type'])
+    if data["suppress_type"] || data["os_version"] >= 2
+      assert_false(index_cmds.first['index'].has_key?("_type"))
+    else
+      assert_true(index_cmds.first['index'].has_key?("_type"))
+      assert_equal(data['_type'], index_cmds.first['index']['_type'])
+    end
   end
 
   def test_writes_to_speficied_host


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

OpenSearch 2 or later seems to be removed type parameter from bulk API:
https://github.com/opensearch-project/OpenSearch/commit/1b571ece28f5644becf97c165de853943af73ac5

Related to #59 

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
