### PR TITLE
Use faraday 1.x explicitly

### DIFF
--- a/fluent-plugin-opensearch.gemspec
+++ b/fluent-plugin-opensearch.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'opensearch-ruby'
   s.add_runtime_dependency "aws-sdk-core", "~> 3"
+  s.add_runtime_dependency "faraday", "~> 1.10"
   s.add_runtime_dependency "faraday_middleware-aws-sigv4"
 
 


### PR DESCRIPTION
opensearch-transport 2.0.1 and 1.0.1 unlocks using faraday 2.x but
fluent-plugin-opensearch isn't ready for it, as a result out_opensearch
doesn't work on newly install.

Fix #70

Signed-off-by: Takuro Ashie <ashie@clear-code.com>

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
