### PR TITLE
Fix link to opensearch-ruby

### DIFF
--- a/README.OpenSearchInput.md
+++ b/README.OpenSearchInput.md
@@ -68,7 +68,7 @@ hosts host1:port1,host2:port2,host3:port3
 
 You can specify multiple OpenSearch hosts with separator ",".
 
-If you specify multiple hosts, this plugin will load balance updates to OpenSearch. This is an [opensearch-ruby](https://github.com/opensearch/opensearch-ruby) feature, the default strategy is round-robin.
+If you specify multiple hosts, this plugin will load balance updates to OpenSearch. This is an [opensearch-ruby](https://github.com/opensearch-project/opensearch-ruby) feature, the default strategy is round-robin.
 
 If you specify `hosts` option, `host` and `port` options are ignored.
 


### PR DESCRIPTION
It just fixes a broken pointer in the documentation

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
