### PR TITLE
Add a constraint for dependent gem

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby 3.0
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
       - name: Build and test with Rake
         run: |
           gem install bundler

--- a/fluent-plugin-opensearch.gemspec
+++ b/fluent-plugin-opensearch.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'opensearch-ruby'
   s.add_runtime_dependency "aws-sdk-core", "~> 3"
   s.add_runtime_dependency "faraday", "~> 1.10"
-  s.add_runtime_dependency "faraday_middleware-aws-sigv4"
-
+  s.add_runtime_dependency "faraday_middleware-aws-sigv4", "~> 0.6.1"
 
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'webrick', '~> 1.7.0'


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

faraday_middleware-aws-sigv4 v0.6.1 is the final version to work with faraday v1.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
