### PR TITLE
Revert "Merge pull request #78 from fluent/pass-credentials-duration"

### DIFF
--- a/test/plugin/test_out_opensearch.rb
+++ b/test/plugin/test_out_opensearch.rb
@@ -300,7 +300,6 @@ class OpenSearchOutputTest < Test::Unit::TestCase
                                       'region' => "local",
                                       'access_key_id' => 'YOUR_AWESOME_KEY',
                                       'secret_access_key' => 'YOUR_AWESOME_SECRET',
-                                      'refresh_credentials_interval' => '10h'
                                     }, []),
         Fluent::Config::Element.new('buffer', 'tag', {}, [])
 
@@ -317,8 +316,6 @@ class OpenSearchOutputTest < Test::Unit::TestCase
     assert_nil instance.endpoint.assume_role_web_identity_token_file
     assert_nil instance.endpoint.sts_credentials_region
     assert_equal :es, instance.endpoint.aws_service_name
-    assert_equal 36000, instance.endpoint.refresh_credentials_interval
-    assert_equal 36000, instance.duration_seconds
   end
 
   data("OpenSearch Service" => [:es, 'es'],


### PR DESCRIPTION
This reverts commit 17e2c49ba5bf336927e806f39e3873ac15b0fdae, reversing changes made to 66012d97be06cdf9b0f492a5d717f9db5a43e549.

This is because duration second should not be set up by default value. Duration second should be user/account dependent.

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
