### PR TITLE
test: remove minitest to correct misjudge of the framework by flexmock

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -55,7 +55,6 @@ end
 
 require 'test/unit'
 require 'fluent/test'
-require 'minitest/pride'
 
 require 'webmock/test_unit'
 WebMock.disable_net_connect!


### PR DESCRIPTION
Fix broken tests: https://github.com/fluent/fluent-plugin-opensearch/pull/109#issuecomment-1682061788

(check all that apply)
- [x] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
