### PR TITLE
pin dependency opensearch-ruby to 3.0.1

### DIFF
--- a/fluent-plugin-opensearch.gemspec
+++ b/fluent-plugin-opensearch.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 2.3".freeze)
 
   s.add_runtime_dependency 'fluentd', '>= 0.14.22'
-  s.add_runtime_dependency 'opensearch-ruby'
+  s.add_runtime_dependency 'opensearch-ruby', '>= 3.0.1'
   s.add_runtime_dependency "aws-sdk-core", "~> 3"
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'faraday', '>= 2.0.0'

--- a/fluent-plugin-opensearch.gemspec
+++ b/fluent-plugin-opensearch.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'webrick', '~> 1.7.0'
-  s.add_development_dependency 'webmock', '~> 3'
+  s.add_development_dependency 'webmock', '~> 3.18.1'
   s.add_development_dependency 'test-unit', '~> 3.3.0'
   s.add_development_dependency 'minitest', '~> 5.8'
   s.add_development_dependency 'flexmock', '~> 2.0'


### PR DESCRIPTION
Since opensearch-ruby recently adapted semantic versioning, we can pin the dependency to 3.0.1.
This Version includes a fix to https://github.com/opensearch-project/opensearch-ruby/issues/205

This will solve #115 and possibly #98

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
