### PR TITLE
out_opensearch_data_stream: Early return on empty body

### DIFF
--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -201,6 +201,8 @@ module Fluent::Plugin
         end
       end
 
+      return if bulk_message.to_s.empty?
+
       params = {
         index: data_stream_name,
         body: bulk_message


### PR DESCRIPTION
Due to some reason the body could be empty which results in infinite jumps between failed buffer flushes. Opensearch returns a 400 with "request body is required".