### PR TITLE
Added a service availability check function for high availability. 

### DIFF
--- a/README.OpenSearchInput.md
+++ b/README.OpenSearchInput.md
@@ -24,6 +24,9 @@
   + [docinfo_fields](#docinfo_fields)
   + [docinfo_target](#docinfo_target)
   + [docinfo](#docinfo)
+  + [infinite_check_connection](#infinite_check_connection)
+  + [test_connection](#test_connection)
+
 * [Advanced Usage](#advanced-usage)
 
 ## Usage
@@ -272,6 +275,22 @@ This parameter specifies whether docinfo information including or not. The defau
 
 ```
 docinfo false
+```
+
+### infinite_check_connection
+
+The parameter infinite checking of connection availability with elasticsearch or opensearch hosts, every 5 seconds. The default value is `true`.
+
+```
+infinite_check_connection true
+```
+
+### test_connection
+
+Retrieves a list of all hosts from the configuration. Checks the availability of each individual service on each host and uses the available servers for communication. The default value is `true`.
+
+```
+test_connection true
 ```
 
 ## Advanced Usage

--- a/README.OpenSearchInput.md
+++ b/README.OpenSearchInput.md
@@ -25,7 +25,6 @@
   + [docinfo_target](#docinfo_target)
   + [docinfo](#docinfo)
   + [infinite_check_connection](#infinite_check_connection)
-  + [test_connection](#test_connection)
 
 * [Advanced Usage](#advanced-usage)
 
@@ -283,14 +282,6 @@ The parameter infinite checking of connection availability with elasticsearch or
 
 ```
 infinite_check_connection true
-```
-
-### test_connection
-
-Retrieves a list of all hosts from the configuration. Checks the availability of each individual service on each host and uses the available servers for communication. The default value is `true`.
-
-```
-test_connection true
 ```
 
 ## Advanced Usage

--- a/lib/fluent/plugin/in_opensearch.rb
+++ b/lib/fluent/plugin/in_opensearch.rb
@@ -1,31 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
-#
-# The fluent-plugin-opensearch Contributors require contributions made to
-# this file be licensed under the Apache-2.0 license or a
-# compatible open source license.
-#
-# Modifications Copyright fluent-plugin-opensearch Contributors. See
-# GitHub history for details.
-#
-# Licensed to Uken Inc. under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Uken Inc. licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 require 'opensearch'
-
 require 'faraday/excon'
 require 'fluent/log-ext'
 require 'fluent/plugin/input'
@@ -179,46 +152,8 @@ module Fluent::Plugin
         host.merge!(path: @path) if !host[:path] && @path
       end
       {
-        hosts: get_reachable_hosts(hosts)
+        hosts: hosts
       }
-    end
-
-    def get_reachable_hosts(hosts=nil)
-
-      reachable_hosts = []
-      attempt = 0
-      loop do
-        hosts.each do |host|
-          begin
-            if @infinite_check_connection == true
-              check_host = OpenSearch::Client.new(
-                host: ["#{host[:scheme]}://#{host[:host]}:#{host[:port]}"],
-                user: host[:user],
-                password: host[:password],
-                reload_connections: true,
-                resurrect_after: @resurrect_after,
-                reload_on_failure: @reload_on_failure,
-                transport_options: { ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version } }
-              )
-              response = check_host.ping  #https://github.com/opensearch-project/opensearch-ruby/blob/136e1c975fc91b8cb80d7d1134e32c6dbefdb3eb/lib/opensearch/api/actions/ping.rb#L33
-              if response == true
-                reachable_hosts << host
-              else
-                log.warn "Connection to #{host[:scheme]}://#{host[:host]}:#{host[:port]} failed with status code #{response.status}"
-              end
-            else
-              reachable_hosts << host
-            end
-          rescue => e
-            log.warn "Failed to connect to #{host[:scheme]}://#{host[:host]}:#{host[:port]}"
-          end
-        end
-        break unless reachable_hosts.empty?
-        log.info "Attempt ##{attempt += 1} to get reachable hosts"
-        log.info "No reachable hosts found. Retrying in #{@request_timeout} seconds..."
-        sleep(@request_timeout)
-      end
-      reachable_hosts
     end
 
     def emit_error_label_event(&block)
@@ -279,40 +214,53 @@ module Fluent::Plugin
     end
 
     def client(host = nil)
-      # check here to see if we already have a client connection for the given host
-      connection_options = get_connection_options(host)
+      retry_count = 0
+      max_retry = @infinite_check_connection ? Float::INFINITY : 3 # Adjust the maximum number of retries as needed
 
-      @_os = nil unless is_existing_connection(connection_options[:hosts])
+      begin
+        connection_options = get_connection_options(host)
+        @_os = nil unless is_existing_connection(connection_options[:hosts])
 
-      @_os ||= begin
-        @current_config = connection_options[:hosts].clone
-        adapter_conf = lambda {|f| f.adapter @http_backend, @backend_options }
-        local_reload_connections = @reload_connections
-        if local_reload_connections && @reload_after > DEFAULT_RELOAD_AFTER
-          local_reload_connections = @reload_after
+        @_os ||= begin
+          @current_config = connection_options[:hosts].clone
+          adapter_conf = lambda {|f| f.adapter @http_backend, @backend_options }
+          local_reload_connections = @reload_connections
+          if local_reload_connections && @reload_after > DEFAULT_RELOAD_AFTER
+            local_reload_connections = @reload_after
+          end
+
+          headers = { 'Content-Type' => "application/json" }.merge(@custom_headers)
+
+          transport = OpenSearch::Transport::Transport::HTTP::Faraday.new(
+            connection_options.merge(
+              options: {
+                reload_connections: local_reload_connections,
+                reload_on_failure: @reload_on_failure,
+                resurrect_after: @resurrect_after,
+                logger: @transport_logger,
+                transport_options: {
+                  headers: headers,
+                  request: { timeout: @request_timeout },
+                  ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
+                },
+                http: {
+                  user: @user,
+                  password: @password
+                },
+                sniffer_class: @sniffer_class,
+              }), &adapter_conf)
+          OpenSearch::Client.new transport: transport
         end
-
-        headers = { 'Content-Type' => "application/json" }.merge(@custom_headers)
-
-        transport = OpenSearch::Transport::Transport::HTTP::Faraday.new(
-          connection_options.merge(
-            options: {
-              reload_connections: local_reload_connections,
-              reload_on_failure: @reload_on_failure,
-              resurrect_after: @resurrect_after,
-              logger: @transport_logger,
-              transport_options: {
-                headers: headers,
-                request: { timeout: @request_timeout },
-                ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
-              },
-              http: {
-                user: @user,
-                password: @password
-              },
-              sniffer_class: @sniffer_class,
-            }), &adapter_conf)
-        OpenSearch::Client.new transport: transport
+      rescue Faraday::ConnectionFailed => e
+        # Retry logic for connection failures during client creation
+        if retry_count < max_retry
+          log.warn "Connection to OpenSearch failed during client creation: #{e.message}. Retrying (Attempt #{retry_count + 1})..."
+          retry_count += 1
+          sleep(@request_timeout)
+          retry
+        else
+          raise UnrecoverableRequestFailure, "Maximum retry attempts reached. Failed to execute OpenSearch search operation."
+        end
       end
     end
 
@@ -344,23 +292,38 @@ module Fluent::Plugin
     end
 
     def run_slice(slice_id=nil)
-      slice_query = @base_query
-      slice_query = slice_query.merge('slice' => { 'id' => slice_id, 'max' => @num_slices}) unless slice_id.nil?
-      result = client.search(@options.merge(:body => Yajl.dump(slice_query) ))
-      es = Fluent::MultiEventStream.new
+      retry_count = 0
+      max_retry = @infinite_check_connection ? Float::INFINITY : 3 # Adjust the maximum number of retries as needed
 
-      result["hits"]["hits"].each {|hit| process_events(hit, es)}
-      has_hits = result['hits']['hits'].any?
-      scroll_id = result['_scroll_id']
+      begin
+        slice_query = @base_query
+        slice_query = slice_query.merge('slice' => { 'id' => slice_id, 'max' => @num_slices}) unless slice_id.nil?
+        result = client.search(@options.merge(:body => Yajl.dump(slice_query) ))
+        es = Fluent::MultiEventStream.new
 
-      while has_hits && scroll_id
-        result = process_next_scroll_request(es, scroll_id)
-        has_hits = result['has_hits']
+        result["hits"]["hits"].each {|hit| process_events(hit, es)}
+        has_hits = result['hits']['hits'].any?
         scroll_id = result['_scroll_id']
-      end
 
-      router.emit_stream(@tag, es)
-      clear_scroll(scroll_id)
+        while has_hits && scroll_id
+          result = process_next_scroll_request(es, scroll_id)
+          has_hits = result['has_hits']
+          scroll_id = result['_scroll_id']
+        end
+
+        router.emit_stream(@tag, es)
+        clear_scroll(scroll_id)
+      rescue Faraday::ConnectionFailed => e
+        # Retry logic for connection failures during search
+        if retry_count < max_retry
+          log.warn "Connection to OpenSearch failed during search: #{e.message}. Retrying (Attempt #{retry_count + 1})..."
+          retry_count += 1
+          sleep(@request_timeout)
+          retry
+        else
+          raise UnrecoverableRequestFailure, "Maximum retry attempts reached. Failed to execute OpenSearch search operation."
+        end
+      end
     end
 
     def clear_scroll(scroll_id)

--- a/lib/fluent/plugin/in_opensearch.rb
+++ b/lib/fluent/plugin/in_opensearch.rb
@@ -360,7 +360,14 @@ module Fluent::Plugin
       end
 
       router.emit_stream(@tag, es)
+      clear_scroll(scroll_id)
+    end
+
+    def clear_scroll(scroll_id)
       client.clear_scroll(scroll_id: scroll_id) if scroll_id
+    rescue => e
+      # ignore & log any clear_scroll errors
+      log.warn("Ignoring clear_scroll exception", message: e.message, exception: e.class)
     end
 
     def process_scroll_request(scroll_id)

--- a/lib/fluent/plugin/in_opensearch.rb
+++ b/lib/fluent/plugin/in_opensearch.rb
@@ -81,7 +81,6 @@ module Fluent::Plugin
     config_param :docinfo_target, :string, :default => METADATA
     config_param :docinfo, :bool, :default => false
     config_param :infinite_check_connection, :bool, :default => true
-    config_param :test_connection, :bool, :default => true
 
     include Fluent::Plugin::OpenSearchConstants
 
@@ -191,7 +190,7 @@ module Fluent::Plugin
       loop do
         hosts.each do |host|
           begin
-            if @test_connection == true
+            if @infinite_check_connection == true
               check_host = OpenSearch::Client.new(
                 host: ["#{host[:scheme]}://#{host[:host]}:#{host[:port]}"],
                 user: host[:user],

--- a/test/plugin/test_in_opensearch.rb
+++ b/test/plugin/test_in_opensearch.rb
@@ -39,7 +39,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
   CONFIG = %[
     tag raw.opensearch
     interval 2
-    test_connection false   # Setting test_connection to false
+    infinite_check_connection false   # Setting infinite_check_connection to false
   ]
 
   def setup
@@ -191,7 +191,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
-      test_connection false   # Setting test_connection to false
+      infinite_check_connection false   # Setting infinite_check_connection to false
     }
     instance = driver(config).instance
 
@@ -230,7 +230,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
-      test_connection false   # Setting test_connection to false
+      infinite_check_connection false   # Setting infinite_check_connection to false
     }
     instance = driver(config).instance
 
@@ -252,7 +252,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     %{j+hn}
       password %{d@e}
       tag      raw.opensearch
-      test_connection false   # Setting test_connection to false
+      infinite_check_connection false   # Setting infinite_check_connection to false
     }
     instance = driver(config).instance
 
@@ -275,7 +275,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       path     /es/
       port     123
       tag      raw.opensearch
-      test_connection false   # Setting test_connection to false
+      infinite_check_connection false   # Setting infinite_check_connection to false
     }
     instance = driver(config).instance
 
@@ -300,7 +300,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
-      test_connection false   # Setting test_connection to false
+      infinite_check_connection false   # Setting infinite_check_connection to false
     }
     instance = driver(config).instance
 
@@ -329,7 +329,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
-      test_connection false   # Setting test_connection to false
+      infinite_check_connection false   # Setting infinite_check_connection to false
     }
     instance = driver(config).instance
 

--- a/test/plugin/test_in_opensearch.rb
+++ b/test/plugin/test_in_opensearch.rb
@@ -39,6 +39,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
   CONFIG = %[
     tag raw.opensearch
     interval 2
+    test_connection false   # Setting test_connection to false
   ]
 
   def setup
@@ -190,6 +191,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
+      test_connection false   # Setting test_connection to false
     }
     instance = driver(config).instance
 
@@ -228,6 +230,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
+      test_connection false   # Setting test_connection to false
     }
     instance = driver(config).instance
 
@@ -249,6 +252,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     %{j+hn}
       password %{d@e}
       tag      raw.opensearch
+      test_connection false   # Setting test_connection to false
     }
     instance = driver(config).instance
 
@@ -271,6 +275,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       path     /es/
       port     123
       tag      raw.opensearch
+      test_connection false   # Setting test_connection to false
     }
     instance = driver(config).instance
 
@@ -295,6 +300,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
+      test_connection false   # Setting test_connection to false
     }
     instance = driver(config).instance
 
@@ -323,6 +329,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
+      test_connection false   # Setting test_connection to false
     }
     instance = driver(config).instance
 

--- a/test/plugin/test_in_opensearch.rb
+++ b/test/plugin/test_in_opensearch.rb
@@ -39,7 +39,6 @@ class OpenSearchInputTest < Test::Unit::TestCase
   CONFIG = %[
     tag raw.opensearch
     interval 2
-    infinite_check_connection false   # Setting infinite_check_connection to false
   ]
 
   def setup
@@ -191,7 +190,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
-      infinite_check_connection false   # Setting infinite_check_connection to false
+
     }
     instance = driver(config).instance
 
@@ -230,7 +229,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
-      infinite_check_connection false   # Setting infinite_check_connection to false
+
     }
     instance = driver(config).instance
 
@@ -252,7 +251,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     %{j+hn}
       password %{d@e}
       tag      raw.opensearch
-      infinite_check_connection false   # Setting infinite_check_connection to false
+
     }
     instance = driver(config).instance
 
@@ -275,7 +274,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       path     /es/
       port     123
       tag      raw.opensearch
-      infinite_check_connection false   # Setting infinite_check_connection to false
+
     }
     instance = driver(config).instance
 
@@ -300,7 +299,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
-      infinite_check_connection false   # Setting infinite_check_connection to false
+
     }
     instance = driver(config).instance
 
@@ -329,7 +328,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
-      infinite_check_connection false   # Setting infinite_check_connection to false
+
     }
     instance = driver(config).instance
 


### PR DESCRIPTION
### Description

**Problem**:
 
If there are two servers in the hosts field (example: hosts "server1:9200,server2:9200"), automatic switching to the available host does not work. If server1 is unavailable, it does not switch to server2, and the service writes an error and freezes:
"Unexpected error raised. Stopping the timer. title=:in_opensearch_timer error_class=Faraday::ConnectionFailed error="EOFError (EOFError)""

**Solution**:
I created a service availability check function for high availability. New function get_reachable_hosts in in_opensearch.rb
I used one library opensearch to solve this problem.

### Checklist

- [ ]  tests added
- [x]  tests passing
- [x] README.OpenSearchInput.md updated
- [ ]  History.md and version in gemspec are untouched
- [x] backward compatible

 
<img width="1079" alt="test_in_opensearch" src="https://github.com/fluent/fluent-plugin-opensearch/assets/39740197/4903227b-9537-4978-a0da-1c8a596af0a5">
