### PR TITLE
Added a retry logic and a service availability check function for high availability.

### DIFF
--- a/README.OpenSearchInput.md
+++ b/README.OpenSearchInput.md
@@ -24,7 +24,16 @@
   + [docinfo_fields](#docinfo_fields)
   + [docinfo_target](#docinfo_target)
   + [docinfo](#docinfo)
-  + [infinite_check_connection](#infinite_check_connection)
+  + [check_connection](#check_connection)
+  + [retry_forever](#retry_forever)
+  + [retry_timeout](#retry_timeout)
+  + [retry_max_times](#retry_max_times)
+  + [retry_type](#retry_type)
+  + [retry_wait](#retry_wait)
+  + [retry_exponential_backoff_base](#retry_exponential_backoff_base)
+  + [retry_max_interval](#retry_max_interval)
+  + [retry_randomize](#retry_randomize)
+
 * [Advanced Usage](#advanced-usage)
 
 ## Usage
@@ -275,14 +284,87 @@ This parameter specifies whether docinfo information including or not. The defau
 docinfo false
 ```
 
-### infinite_check_connection
+### check_connection
 
-The parameter infinite checking on connection availability with Elasticsearch or opensearch hosts, every  request_timeout (default 5) seconds. The default value is `true`.
+The parameter for checking on connection availability with Elasticsearch or Opensearch hosts. The default value is `true`.
 
 ```
-infinite_check_connection true
+check_connection true
+```
+### retry_forever
+
+The parameter If true, plugin will ignore retry_timeout and retry_max_times options and retry forever. The default value is `true`.
+
+```
+retry_forever true
 ```
 
+### retry_timeout
+
+The parameter maximum time (seconds) to retry again the failed try, until the plugin discards the retry.
+If the next retry is going to exceed this time limit, the last retry will be made at exactly this time limit..
+The default value is `72h`.
+72hours == 17 times with exponential backoff (not to change default behavior)
+
+```
+retry_timeout 72 * 60 * 60
+```
+
+### retry_max_times
+
+The parameter maximum number of times to retry the failed try. The default value is `5`
+
+```
+retry_max_times 5
+```
+
+### retry_type
+
+The parameter needs for how long need to wait (time in seconds) to retry again:
+`exponential_backoff`: wait in seconds will become large exponentially per failure,
+`periodic`: plugin will retry periodically with fixed intervals (configured via retry_wait). The default value is `:exponential_backoff`
+Periodic -> fixed :retry_wait
+Exponential backoff: k is number of retry times
+c: constant factor, @retry_wait
+b: base factor, @retry_exponential_backoff_base
+k: times
+total retry time: c + c * b^1 + (...) + c*b^k = c*b^(k+1) - 1
+
+```
+retry_type exponential_backoff
+```
+
+### retry_wait
+
+The parameter needs for wait in seconds before the next retry to again or constant factor of exponential backoff. The default value is  `5`
+
+```
+retry_wait 5
+```
+
+### retry_exponential_backoff_base
+
+The parameter The base number of exponential backoff for retries. The default value is  `2`
+
+```
+retry_exponential_backoff_base 2
+```
+
+### retry_max_interval
+
+The parameter maximum interval (seconds) for exponential backoff between retries while failing. The default value is  `nil`
+
+```
+retry_max_interval nil
+```
+
+### retry_randomize
+
+The parameter If true, the plugin will retry after randomized interval not to do burst retries. The default value is  `false`
+
+```
+retry_randomize false
+```
 
 ## Advanced Usage
 

--- a/README.OpenSearchInput.md
+++ b/README.OpenSearchInput.md
@@ -277,7 +277,7 @@ docinfo false
 
 ### infinite_check_connection
 
-The parameter infinite checking on connection availability with Elasticsearch or opensearch hosts, every  request_timeout (default 5) seconds. The default value is `true,`. But if value is `false` then checking of connection will be only 3 times
+The parameter infinite checking on connection availability with Elasticsearch or opensearch hosts, every  request_timeout (default 5) seconds. The default value is `true`.
 
 ```
 infinite_check_connection true

--- a/README.OpenSearchInput.md
+++ b/README.OpenSearchInput.md
@@ -24,6 +24,7 @@
   + [docinfo_fields](#docinfo_fields)
   + [docinfo_target](#docinfo_target)
   + [docinfo](#docinfo)
+  + [infinite_check_connection](#infinite_check_connection)
 * [Advanced Usage](#advanced-usage)
 
 ## Usage
@@ -273,6 +274,15 @@ This parameter specifies whether docinfo information including or not. The defau
 ```
 docinfo false
 ```
+
+### infinite_check_connection
+
+The parameter infinite checking on connection availability with Elasticsearch or opensearch hosts, every  request_timeout (default 5) seconds. The default value is `true,`. But if value is `false` then checking of connection will be only 3 times
+
+```
+infinite_check_connection true
+```
+
 
 ## Advanced Usage
 

--- a/lib/fluent/plugin/in_opensearch.rb
+++ b/lib/fluent/plugin/in_opensearch.rb
@@ -349,8 +349,10 @@ module Fluent::Plugin
         log.warn("failed to connect or search.", retry_times: @retry.steps, next_retry_time: @retry.next_time.round, error: error.message)
         sleep(@retry.next_time - Time.now)
       else
-        log.debug("retry succeeded.") unless @retry.nil?
-        @retry = nil unless @retry.nil?
+        unless @retry.nil?
+          log.debug("retry succeeded.")
+          @retry = nil
+        end
       end
     end
 

--- a/test/plugin/test_in_opensearch.rb
+++ b/test/plugin/test_in_opensearch.rb
@@ -39,6 +39,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
   CONFIG = %[
     tag raw.opensearch
     interval 2
+    infinite_check_connection false
   ]
 
   def setup
@@ -190,6 +191,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
+      infinite_check_connection false
     }
     instance = driver(config).instance
 
@@ -228,6 +230,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
+      infinite_check_connection false
     }
     instance = driver(config).instance
 
@@ -249,6 +252,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     %{j+hn}
       password %{d@e}
       tag      raw.opensearch
+      infinite_check_connection false
     }
     instance = driver(config).instance
 
@@ -271,6 +275,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       path     /es/
       port     123
       tag      raw.opensearch
+      infinite_check_connection false
     }
     instance = driver(config).instance
 
@@ -295,6 +300,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
+      infinite_check_connection false
     }
     instance = driver(config).instance
 
@@ -323,6 +329,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
+      infinite_check_connection false
     }
     instance = driver(config).instance
 

--- a/test/plugin/test_in_opensearch.rb
+++ b/test/plugin/test_in_opensearch.rb
@@ -39,7 +39,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
   CONFIG = %[
     tag raw.opensearch
     interval 2
-    infinite_check_connection false
+    check_connection false
   ]
 
   def setup
@@ -191,7 +191,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
-      infinite_check_connection false
+      check_connection false
     }
     instance = driver(config).instance
 
@@ -230,7 +230,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     john
       password doe
       tag      raw.opensearch
-      infinite_check_connection false
+      check_connection false
     }
     instance = driver(config).instance
 
@@ -252,7 +252,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     %{j+hn}
       password %{d@e}
       tag      raw.opensearch
-      infinite_check_connection false
+      check_connection false
     }
     instance = driver(config).instance
 
@@ -275,7 +275,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       path     /es/
       port     123
       tag      raw.opensearch
-      infinite_check_connection false
+      check_connection false
     }
     instance = driver(config).instance
 
@@ -300,7 +300,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
-      infinite_check_connection false
+      check_connection false
     }
     instance = driver(config).instance
 
@@ -329,7 +329,7 @@ class OpenSearchInputTest < Test::Unit::TestCase
       user     default_user
       password default_password
       tag      raw.opensearch
-      infinite_check_connection false
+      check_connection false
     }
     instance = driver(config).instance
 


### PR DESCRIPTION
### Description

**Problem**: 
If there are two servers in the hosts field (example: hosts "server1:9200,server2:9200"), automatic switching to the available host does not work. If server1 is unavailable, it does not switch to server2, and the service writes an error and freezes:
"Unexpected error raised. Stopping the timer. title=:in_opensearch_timer error_class=Faraday::ConnectionFailed error="EOFError (EOFError)""

**Solution**:
I added a retry logic in case of connection failures. 
I created a service availability check function for high availability. New function get_reachable_hosts in in_opensearch.rb
I used one library opensearch to solve this problem.
And added ignoring any clear_scroll errors.

### Checklist

- [ ]  tests added
- [x]  tests passing
- [x] README.OpenSearchInput.md updated
- [ ]  History.md and version in gemspec are untouched
- [x] backward compatible

<img width="1192" alt="Monosnap Dockerfile—2024-04-14 14-18-21" src="https://github.com/fluent/fluent-plugin-opensearch/assets/39740197/e2de88f3-721b-43ac-835b-d91cd2a5eb65">
