### PR TITLE
Prevent AWS credentials refresh from stopping on exception

### DIFF
--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -350,7 +350,11 @@ module Fluent::Plugin
 
             @credential_mutex.synchronize do
               @_os = nil
-              @_aws_credentials = aws_credentials(@endpoint)
+              begin
+                @_aws_credentials = aws_credentials(@endpoint)
+              rescue => e
+                log.error("Failed to get new AWS credentials: #{e}")
+              end
             end
           end
         end


### PR DESCRIPTION
If `aws_credentials()` fails due to an unstable network or other issues, it throws an exception. This stops `timer_execute()` from repeating its block, preventing `OpenSearchOutput` from updating `@_aws_credentials`. As a result, `@_aws_credentials` will expire.

This commit catches the exception and prevents it from propagating to `timer_execute()`, ensuring continuous credential updates.