### PR TITLE
Fix bundle installation error on GitHub Action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,5 +22,6 @@ jobs:
         CI: true
       run: |
         gem install bundler rake
+        bundle config set path 'vendor/bundle'
         bundle install --jobs 4 --retry 3
         bundle exec rake test


### PR DESCRIPTION
This commit attempts to fix the GitHub Actions failure in [PR #142](https://github.com/fluent/fluent-plugin-opensearch/pull/142).

Ruby 3.2 Unit Testing on ubuntu-latest
```
The installation path is insecure. Bundler cannot continue.
/opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems is world-writable (without sticky bit).
Bundler cannot safely replace gems in world-writable directories due to potential vulnerabilities.
Please change the permissions of this directory or choose a different install path.
Error: Process completed with exit code 38.
```


The last commit to the main branch was successful, but it was 5 months ago (Apr 30). It seems that an update to Ruby or Bundler may have broken the Action.

Based on my testing in my repository, this fix resolves the issue: [PR #1](https://github.com/aYukiSekiguchi/fluent-plugin-opensearch/pull/1).
