### PR TITLE
Fix memory usage

### DIFF
--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -885,10 +885,10 @@ module Fluent::Plugin
           if split_request?(bulk_message, info)
             bulk_message.each do |info, msgs|
               send_bulk(msgs, tag, chunk, bulk_message_count[info], extracted_values, info) unless msgs.empty?
+            ensure
               msgs.clear
               # Clear bulk_message_count for this info.
               bulk_message_count[info] = 0;
-              next
             end
           end
 
@@ -910,6 +910,7 @@ module Fluent::Plugin
 
       bulk_message.each do |info, msgs|
         send_bulk(msgs, tag, chunk, bulk_message_count[info], extracted_values, info) unless msgs.empty?
+      ensure
         msgs.clear
       end
     end


### PR DESCRIPTION
fluent-plugin-opensearch has the codes that are very similar to fluent-plugin-elasticsearch.
I have sent a PR to fluent-plugin-elasticsearch to fix memory usage issue when raising an exception on sending data
at https://github.com/uken/fluent-plugin-elasticsearch/pull/1065


This PR will fix the same issue in fluent-plugin-opensearch.