### PR TITLE
out_opensearch: fix default value of refresh_credentials_interval

### DIFF
--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -195,7 +195,7 @@ module Fluent::Plugin
       config_param :assume_role_session_name, :string, :default => "fluentd"
       config_param :assume_role_web_identity_token_file, :string, :default => nil
       config_param :sts_credentials_region, :string, :default => nil
-      config_param :refresh_credentials_interval, :time, :default => "5h"
+      config_param :refresh_credentials_interval, :time, :default => 18000 # 5 hours
       config_param :aws_service_name, :enum, list: [:es, :aoss], :default => :es
     end
 


### PR DESCRIPTION
Fix #130

Currently, when using the default value for `refresh_credentials_interval`,
the string `"5h"` is passed to the `interval` argument of `timer_execute` method.

However, `interval` argument supports `integer` or `float` value.

Ref. https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-timer#timer_execute-title-interval-repeat-true-and-block