### PR TITLE
Add log_failure_only option to reduce bulk response log verbosity

### DIFF
--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -167,6 +167,8 @@ module Fluent::Plugin
     config_param :verify_os_version_at_startup, :bool, :default => true
     config_param :default_opensearch_version, :integer, :default => DEFAULT_OPENSEARCH_VERSION
     config_param :log_os_400_reason, :bool, :default => false
+    config_param :log_failure_only, :bool, :default => false,
+                 :desc => 'When true, bulk response trace log includes only failed items instead of the full response.'
     config_param :custom_headers, :hash, :default => {}
     config_param :suppress_doc_wrap, :bool, :default => false
     config_param :ignore_exceptions, :array, :default => [], value_type: :string, :desc => "Ignorable exception list"
@@ -1109,7 +1111,15 @@ module Fluent::Plugin
                         end
 
         response = client(info.host, compression).bulk body: prepared_data, index: info.index
-        log.on_trace { log.trace "bulk response: #{response}" }
+        log.on_trace do
+          loggable = if @log_failure_only && response.is_a?(Hash) && response['items'].is_a?(Array)
+                       failed = response['items'].select { |i| i.values.first.key?('error') }
+                       response.merge('items' => failed)
+                     else
+                       response
+                     end
+          log.trace "bulk response: #{loggable}"
+        end
 
         if response['errors']
           error = Fluent::Plugin::OpenSearchErrorHandler.new(self)


### PR DESCRIPTION
## Summary

Closes #173

- Adds `log_failure_only` boolean config param (default `false`, fully backwards-compatible)
- When enabled, the bulk response trace log serializes only items that contain an `error` field, instead of the full response
- No changes to error handling logic — only affects what is serialized in the `log.on_trace` call in `send_bulk`

## Motivation

In high-throughput deployments, a single bulk request can contain hundreds of records. When `log_level trace` is active, `out_opensearch` logs the complete response object — including all successful items — generating messages of 10–20 KB per request. With one failed record out of 500, the operator gets ~15 KB of noise to find a ~200-byte error entry.

This option lets operators keep trace logging enabled for debugging while eliminating the volume problem.

## Changes

**`lib/fluent/plugin/out_opensearch.rb`**

- New `config_param :log_failure_only` after `log_os_400_reason` (line 169)
- `send_bulk`: replaced `log.on_trace { log.trace "bulk response: #{response}" }` with a block that conditionally filters `response['items']` to failed entries only

## Backwards compatibility

Default is `false` — existing behaviour is unchanged.

## Tests needed

- `test_log_failure_only_filters_successful_items` — verify only items with `error` key are logged when option is `true`
- `test_log_failure_only_false_logs_full_response` — verify full response is logged when option is `false` (default)
- `test_log_failure_only_no_items_key` — verify graceful passthrough when response has no `items` key