### PR TITLE
fix: filter failed items in data stream bulk error log

### DIFF
--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -210,7 +210,8 @@ module Fluent::Plugin
       begin
         response = client(host).bulk(params)
         if response['errors']
-          log.error "Could not bulk insert to Data Stream: #{data_stream_name} #{response}"
+          failed = response['items'].select { |item| item.values.first['status'] >= 300 }
+          log.error "Could not bulk insert to Data Stream: #{data_stream_name}, failed items: #{failed}"
         end
       rescue => e
         raise RecoverableRequestFailure, "could not push logs to OpenSearch cluster (#{data_stream_name}): #{e.message}"
@@ -229,3 +230,4 @@ module Fluent::Plugin
     end
   end
 end
+

--- a/lib/fluent/plugin/out_opensearch_data_stream.rb
+++ b/lib/fluent/plugin/out_opensearch_data_stream.rb
@@ -174,6 +174,7 @@ module Fluent::Plugin
         CREATE_OP => {}
       }
       tag = chunk.metadata.tag
+      records = []
       chunk.msgpack_each do |time, record|
         next unless record.is_a? Hash
         begin
@@ -194,6 +195,7 @@ module Fluent::Plugin
             @remove_keys.each { |key| record.delete(key) }
           end
           bulk_message = append_record_to_messages(CREATE_OP, {}, headers, record, bulk_message)
+          records << [time, record]
         rescue => e
           emit_error_label_event do
             router.emit_error_event(tag, time, record, e)
@@ -210,8 +212,18 @@ module Fluent::Plugin
       begin
         response = client(host).bulk(params)
         if response['errors']
-          failed = response['items'].select { |item| item.values.first['status'] >= 300 }
-          log.error "Could not bulk insert to Data Stream: #{data_stream_name}, failed items: #{failed}"
+          failed_count = response['items'].count { |item| item.values.first['status'] >= 300 }
+          log.error "Could not bulk insert to Data Stream: #{data_stream_name}, #{failed_count} item(s) failed."
+          if emit_error_label_event?
+            response['items'].each_with_index do |item, idx|
+              status = item.values.first['status']
+              next unless status >= 300
+              time, record = records[idx]
+              next if record.nil?
+              error_info = item.values.first['error']
+              router.emit_error_event(tag, time, record, RuntimeError.new("status #{status}: #{error_info}"))
+            end
+          end
         end
       rescue => e
         raise RecoverableRequestFailure, "could not push logs to OpenSearch cluster (#{data_stream_name}): #{e.message}"

--- a/test/plugin/test_out_opensearch_data_stream.rb
+++ b/test/plugin/test_out_opensearch_data_stream.rb
@@ -769,8 +769,7 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     end
     error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
     assert_not_nil error_log, "Expected an error log entry for bulk insert failure"
-    assert_match(/failed items:/, error_log)
-    assert_match(/400/, error_log)
+    assert_match(/1 item\(s\) failed/, error_log)
     assert_no_match(/201/, error_log)
   end
 
@@ -799,8 +798,75 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     end
     error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
     assert_not_nil error_log, "Expected an error log entry for bulk insert failure"
-    assert_match(/500/, error_log)
-    assert_no_match(/\"status\"=>200/, error_log)
+    assert_match(/1 item\(s\) failed/, error_log)
+    assert_no_match(/200/, error_log)
+  end
+
+  def test_bulk_error_emits_failed_records_to_error_label
+    stub_default
+    stub_request(:post, "http://localhost:9200/foo/_bulk").to_return(
+      status: 200,
+      body: {
+        'errors' => true,
+        'items' => [
+          { 'create' => { 'status' => 201, '_index' => 'foo' } },
+          { 'create' => { 'status' => 400, '_index' => 'foo',
+                          'error' => { 'type' => 'mapper_parsing_exception', 'reason' => 'failed to parse' } } }
+        ]
+      }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => OPENSEARCH_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo',
+        'data_stream_template_name' => 'foo_tpl',
+        'emit_error_label_event' => 'true'
+      })
+    error_events = []
+    flexmock(Fluent::Engine).should_receive(:emit_error_event).and_return { |tag, time, record, e|
+      error_events << { tag: tag, record: record, error: e }
+    }
+    d = driver(conf)
+    flexmock(d.instance.router).should_receive(:emit_error_event).and_return { |tag, time, record, e|
+      error_events << { tag: tag, record: record, error: e }
+    }
+    d.run(default_tag: 'test') do
+      d.feed(event_time, sample_record)
+      d.feed(event_time, sample_record)
+    end
+    assert_equal 1, error_events.size, "Expected exactly one record routed to @ERROR"
+    assert_match(/400/, error_events.first[:error].message)
+  end
+
+  def test_bulk_error_does_not_emit_error_events_when_disabled
+    stub_default
+    stub_request(:post, "http://localhost:9200/foo/_bulk").to_return(
+      status: 200,
+      body: {
+        'errors' => true,
+        'items' => [
+          { 'create' => { 'status' => 400, '_index' => 'foo',
+                          'error' => { 'type' => 'mapper_parsing_exception', 'reason' => 'failed to parse' } } }
+        ]
+      }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => OPENSEARCH_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo',
+        'data_stream_template_name' => 'foo_tpl',
+        'emit_error_label_event' => 'false'
+      })
+    error_events = []
+    d = driver(conf)
+    flexmock(d.instance.router).should_receive(:emit_error_event).never
+    d.run(default_tag: 'test') do
+      d.feed(event_time, sample_record)
+    end
+    error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
+    assert_not_nil error_log, "Expected summary error log even when emit_error_label_event is false"
   end
 
 end

--- a/test/plugin/test_out_opensearch_data_stream.rb
+++ b/test/plugin/test_out_opensearch_data_stream.rb
@@ -743,4 +743,65 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     assert(!index_cmds[1].has_key?('remove_me'))
   end
 
+  def test_bulk_error_logs_only_failed_items
+    stub_default
+    stub_request(:post, "http://localhost:9200/foo/_bulk").to_return(
+      status: 200,
+      body: {
+        'errors' => true,
+        'items' => [
+          { 'create' => { 'status' => 201, '_index' => 'foo' } },
+          { 'create' => { 'status' => 201, '_index' => 'foo' } },
+          { 'create' => { 'status' => 400, '_index' => 'foo',
+                          'error' => { 'type' => 'mapper_parsing_exception', 'reason' => 'failed to parse' } } }
+        ]
+      }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => OPENSEARCH_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo',
+        'data_stream_template_name' => 'foo_tpl'
+      })
+    driver(conf).run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
+    assert_not_nil error_log, "Expected an error log entry for bulk insert failure"
+    assert_match(/failed items:/, error_log)
+    assert_match(/400/, error_log)
+    assert_no_match(/201/, error_log)
+  end
+
+  def test_bulk_error_logs_5xx_items
+    stub_default
+    stub_request(:post, "http://localhost:9200/foo/_bulk").to_return(
+      status: 200,
+      body: {
+        'errors' => true,
+        'items' => [
+          { 'create' => { 'status' => 200, '_index' => 'foo' } },
+          { 'create' => { 'status' => 500, '_index' => 'foo',
+                          'error' => { 'type' => 'internal_server_error' } } }
+        ]
+      }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => OPENSEARCH_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo',
+        'data_stream_template_name' => 'foo_tpl'
+      })
+    driver(conf).run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
+    assert_not_nil error_log, "Expected an error log entry for bulk insert failure"
+    assert_match(/500/, error_log)
+    assert_no_match(/\"status\"=>200/, error_log)
+  end
+
 end
+

--- a/test/plugin/test_out_opensearch_data_stream.rb
+++ b/test/plugin/test_out_opensearch_data_stream.rb
@@ -767,7 +767,7 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     driver(conf).run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
+    error_log = driver.logs.find { |l| l.include?("Could not bulk insert") }
     assert_not_nil error_log, "Expected an error log entry for bulk insert failure"
     assert_match(/1 item\(s\) failed/, error_log)
     assert_no_match(/201/, error_log)
@@ -796,7 +796,7 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     driver(conf).run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
+    error_log = driver.logs.find { |l| l.include?("Could not bulk insert") }
     assert_not_nil error_log, "Expected an error log entry for bulk insert failure"
     assert_match(/1 item\(s\) failed/, error_log)
     assert_no_match(/200/, error_log)
@@ -865,7 +865,7 @@ class OpenSearchOutputDataStreamTest < Test::Unit::TestCase
     d.run(default_tag: 'test') do
       d.feed(event_time, sample_record)
     end
-    error_log = Fluent::Engine.log.out.logs.find { |l| l.include?("Could not bulk insert") }
+    error_log = d.logs.find { |l| l.include?("Could not bulk insert") }
     assert_not_nil error_log, "Expected summary error log even when emit_error_label_event is false"
   end
 


### PR DESCRIPTION
## Summary

Fixes #173

When `response['errors']` is true in `out_opensearch_data_stream.rb`, the current code logs the entire bulk response at `error` level — including all successful items alongside the failed ones. In high-throughput deployments, this generates log lines with thousands of characters per flush cycle.

This PR filters the logged items to include only those with `status >= 300`, as suggested by @Watson1978 in the issue discussion.

## Changes

**`lib/fluent/plugin/out_opensearch_data_stream.rb`**

```ruby
# Before
if response['errors']
  log.error "Could not bulk insert to Data Stream: #{data_stream_name} #{response}"
end

# After
if response['errors']
  failed = response['items'].select { |item| item.values.first['status'] >= 300 }
  log.error "Could not bulk insert to Data Stream: #{data_stream_name}, failed items: #{failed}"
end
```

## Why `>= 300`

Using `>= 300` instead of `!= 201` is more robust: it correctly handles any 2xx success status (200, 201, 202) that OpenSearch may return, rather than treating non-201 successes as failures.

## Note

This supersedes PR #174, which was closed because it targeted `out_opensearch.rb` (the `log.on_trace` path) rather than the actual source of the problem in `out_opensearch_data_stream.rb`.