### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ compression_level best_compression
 
 ### prefer_oj_serializer
 
-With default behavior, OpenSearch client uses `Yajl` as JSON encoder/decoder.
+With default behavior, OpenSearch client uses `JSON` as JSON encoder/decoder.
 `Oj` is the alternative high performance JSON encoder/decoder.
 When this parameter sets as `true`, OpenSearch client uses `Oj` as JSON encoder/decoder.
 

--- a/lib/fluent/plugin/in_opensearch.rb
+++ b/lib/fluent/plugin/in_opensearch.rb
@@ -374,7 +374,7 @@ module Fluent::Plugin
     def run_slice(slice_id=nil)
       slice_query = @base_query
       slice_query = slice_query.merge('slice' => { 'id' => slice_id, 'max' => @num_slices}) unless slice_id.nil?
-      result = client.search(@options.merge(:body => Yajl.dump(slice_query) ))
+      result = client.search(@options.merge(:body => JSON.generate(slice_query) ))
       es = Fluent::MultiEventStream.new
 
       result["hits"]["hits"].each {|hit| process_events(hit, es)}

--- a/lib/fluent/plugin/out_opensearch.rb
+++ b/lib/fluent/plugin/out_opensearch.rb
@@ -369,7 +369,7 @@ module Fluent::Plugin
           OpenSearch::API.settings[:serializer] = Fluent::Plugin::Serializer::Oj
         end
       rescue LoadError
-        @dump_proc = Yajl.method(:dump)
+        @dump_proc = JSON.method(:generate)
       end
 
       raise Fluent::ConfigError, "`password` must be present if `user` is present" if @user && @password.nil?
@@ -940,7 +940,7 @@ module Fluent::Plugin
             {"_index" => {"order" => "desc"}}
          ]
         }
-        result = client.search(options.merge(:body => Yajl.dump(query)))
+        result = client.search(options.merge(:body => JSON.generate(query)))
         # There should be just one hit per _id, but in case there still is multiple, just the oldest index is stored to map
         result['hits']['hits'].each do |hit|
           indices[hit["_id"]] = hit["_index"]


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.